### PR TITLE
fix: updated bash enter check for pre-commit

### DIFF
--- a/dev/enter.sh
+++ b/dev/enter.sh
@@ -1,9 +1,9 @@
 # shellcheck shell=bash
-if [ -e "$PWD/poetry.lock" ] && [ -n "$(type -P poetry)" ] && [ -n "$(type -P pre-commit)" ]; then
+if [ -e "$PWD/poetry.lock" ] && [ -n "$(type -P poetry)" ] && [ -z "$(type -P pre-commit)" ]; then
   if poetry install; then
     poetry update
   fi
-elif [ -n "$(type -P poetry)" ] && [ -n "$(type -P pre-commit)" ]; then
+elif [ -n "$(type -P poetry)" ] && [ -z "$(type -P pre-commit)" ]; then
   poetry update
 fi
 hash -r


### PR DESCRIPTION
pre-commit is installed by poetry so it should not be available before
poetry update/install
