### PR TITLE
fix: enter scripts no longer update dev environment

### DIFF
--- a/dev/enter.csh
+++ b/dev/enter.csh
@@ -1,13 +1,17 @@
-if ( -e $PWD/poetry.lock && "`where poetry`" != "" && "`where pre-commit`" == "" ) then
+#
+## tcsh/csh script when entering conda virtual env
+
+# install pyproject environemnt and project
+if ( "`where poetry`" != "" ) then
   poetry install
-  if ( $? ) then
-    poetry update
-  endif
-else if ( "`where  poetry`" != "" && "`where pre-commit`" == "" ) then
-  poetry update
+else
+  echo "Error: No poetry here."
 endif
+
+# update shell
 rehash
 
+# install pre-commit hooks
 if ( $?git_root ) then
   if ( "`where pre-commit`" != "" ) then
     if ( ! -e "$git_root/.git/hooks/commit-msg" ) then

--- a/dev/enter.sh
+++ b/dev/enter.sh
@@ -1,13 +1,17 @@
 # shellcheck shell=bash
-if [ -e "$PWD/poetry.lock" ] && [ -n "$(type -P poetry)" ] && [ -z "$(type -P pre-commit)" ]; then
-  if poetry install; then
-    poetry update
-  fi
-elif [ -n "$(type -P poetry)" ] && [ -z "$(type -P pre-commit)" ]; then
-  poetry update
+## bash script when entering conda virtual env
+
+# install pyproject environment and project
+if [ -n "$(type -P poetry)" ]; then
+  poetry install
+else
+  echo "Error: No poetry here."
 fi
+
+# update shell
 hash -r
 
+# install pre-commit hooks
 # shellcheck disable=SC2154 # variables exist in environment
 if [ -n "$git_root" ]; then
   if [ -n "$(type -P pre-commit)" ]; then


### PR DESCRIPTION
Auto activation scripts will no longer update poetry packages.
Changed call to check if poetry available and install.
This will now bring env to locked status or create lock.
As well it will install the project in the path.

Close #6
